### PR TITLE
Fix issue that prevents compiling for ESP8266

### DIFF
--- a/dht_nonblocking.cpp
+++ b/dht_nonblocking.cpp
@@ -169,7 +169,7 @@ uint32_t DHT_nonblocking::expect_pulse(bool level) const
 /*
  * State machine of the non-blocking read.
  */
-boolean DHT_nonblocking::read_nonblocking( )
+bool DHT_nonblocking::read_nonblocking( )
 {
   bool status = false;
 

--- a/dht_nonblocking.h
+++ b/dht_nonblocking.h
@@ -41,8 +41,8 @@ class DHT_nonblocking
     bool measure( float *temperature, float *humidity );
 
   private:
-    boolean read_data( );
-    boolean read_nonblocking( );
+    bool read_data( );
+    bool read_nonblocking( );
     float read_temperature( ) const;
     float read_humidity( ) const;
 


### PR DESCRIPTION
Fixes error:

    prototype for 'bool DHT_nonblocking::read_data()' does not match any in class 'DHT_nonblocking'