### PR TITLE
3 small changes

### DIFF
--- a/dht_nonblocking.cpp
+++ b/dht_nonblocking.cpp
@@ -81,8 +81,8 @@ float DHT_nonblocking::read_temperature( ) const
   {
   case DHT_TYPE_11:
     to_return = data[2];
-    if (data[3] & 0x80) to_return = -1. - to_return;
     to_return += (data[3] & 0x0f) * 0.1;
+    if (data[3] & 0x80) to_return = -1. - to_return;
     break;
 
   case DHT_TYPE_21:

--- a/dht_nonblocking.cpp
+++ b/dht_nonblocking.cpp
@@ -30,7 +30,7 @@
 
 
 /* Number of milliseconds before a new sensor read may be initiated. */
-#define COOLDOWN_TIME  2000
+#define COOLDOWN_TIME  10000
 
 
 /*
@@ -80,8 +80,9 @@ float DHT_nonblocking::read_temperature( ) const
   switch( _type )
   {
   case DHT_TYPE_11:
-    value = data[ 2 ];
-    to_return = (float) value;
+    to_return = data[2];
+    if (data[3] & 0x80) to_return = -1. - to_return;
+    to_return += (data[3] & 0x0f) * 0.1;
     break;
 
   case DHT_TYPE_21:

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Non-blocking DHT11, DHT21, and DHT22 sensor library
 paragraph=Read temperature and humidity from the DHT11, DHT21, and DHT22 sensors without blocking other execution.
 category=Sensors
 url=https://github.com/olewolf/DHT_nonblocking
-architectures=avr,esp8266
+architectures=avr,esp8266,esp32


### PR DESCRIPTION
1. Increased COOLDOWN_TIME to 10 sec because I was seeing about 1 degree of self-heat at 2 sec.
2. Followed Adafruit's for 0.1 degree resolution on DHT11.
3. Add esp32 to architectures to quash warning. No problems seen.